### PR TITLE
g_string memleak fix in recipe_handler and task_handler

### DIFF
--- a/src/recipe.c
+++ b/src/recipe.c
@@ -636,8 +636,8 @@ recipe_handler (gpointer user_data)
                                     message->str,
                                     message->len);
       }
-      g_string_free(message, TRUE);
     }
 
+    g_string_free(message, TRUE);
     return result;
 }

--- a/src/task.c
+++ b/src/task.c
@@ -794,7 +794,7 @@ task_handler (gpointer user_data)
   if (message->len) {
     write (STDERR_FILENO, message->str, message->len);
     connections_write(app_data, message->str, message->len);
-    g_string_free(message, TRUE);
   }
+  g_string_free(message, TRUE);
   return result;
 }


### PR DESCRIPTION
g_strings should be freed regardles of whether they contain actual data or not.
