### PR TITLE
Fixed premature g_clear_error()

### DIFF
--- a/src/fetch_git.c
+++ b/src/fetch_git.c
@@ -334,7 +334,6 @@ archive_finish_callback (gpointer user_data)
                                      fetch_data->user_data);
     }
 
-    g_clear_error (&fetch_data->error);
     if (fetch_data != NULL)
         g_slice_free(FetchData, fetch_data);
     return FALSE;

--- a/src/fetch_http.c
+++ b/src/fetch_http.c
@@ -118,7 +118,6 @@ archive_finish_callback (gpointer user_data)
     soup_session_abort (session);
     g_object_unref (session);
 
-    g_clear_error (&fetch_data->error);
     if (fetch_data != NULL)
         g_slice_free(FetchData, fetch_data);
     return FALSE;

--- a/src/task.c
+++ b/src/task.c
@@ -840,6 +840,7 @@ task_handler (gpointer user_data)
       // Some step along the way failed.
       if (task->error) {
         restraint_task_status(task, app_data, "Aborted", task->error);
+        g_clear_error(&task->error);
       } else {
         restraint_task_status(task, app_data, "Completed", NULL);
       }


### PR DESCRIPTION
When task fails while being fetched error is prematurely cleared in
archive_finish_callback of both fetch_git.c and fetch_http.c.
This patch moves g_clear_error() to task_handler() after it is sent to the
client.
