### PR TITLE
Fix restraint client to support recipe params

### DIFF
--- a/releasenotes/notes/client_recipe_params-44e597287474ee53.yaml
+++ b/releasenotes/notes/client_recipe_params-44e597287474ee53.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    restraint client now honors recipe params as well as task params.

--- a/src/client.c
+++ b/src/client.c
@@ -1377,6 +1377,15 @@ static gchar *copy_job_as_template(gchar *job, gboolean novalid,
                                            recipe_set_node_ptr, wboard,
                                            role, owner, family);
 
+            // Copy recipe params
+            xmlXPathObjectPtr params_node = get_node_set(template_xml_doc_ptr,
+                    node, (xmlChar*)"params");
+            if (params_node) {
+                xmlNodePtr copy_params_node_ptr = xmlDocCopyNode(params_node->nodesetval->nodeTab[0],
+                                                  new_xml_doc_ptr, 1);
+                xmlAddChild (new_recipe_ptr, copy_params_node_ptr);
+            }
+
             // find task nodes
             xmlXPathObjectPtr task_nodes = get_node_set(template_xml_doc_ptr,
                     node, (xmlChar*)"task");

--- a/src/client.c
+++ b/src/client.c
@@ -1384,6 +1384,8 @@ static gchar *copy_job_as_template(gchar *job, gboolean novalid,
                 xmlNodePtr copy_params_node_ptr = xmlDocCopyNode(params_node->nodesetval->nodeTab[0],
                                                   new_xml_doc_ptr, 1);
                 xmlAddChild (new_recipe_ptr, copy_params_node_ptr);
+                xmlXPathFreeObject(params_node);
+                params_node = NULL;
             }
 
             // find task nodes


### PR DESCRIPTION
This PR fixes a bug in restraint client where it doesn't
honor recipe level params.

Change-Id: I6fd600327cdf951d00f0d66e6a1283eccbe8d223